### PR TITLE
COM-10354 Use proper name for thirdpartyworkflow checkout settings

### DIFF
--- a/assets/src/paypal/constants.js
+++ b/assets/src/paypal/constants.js
@@ -1,9 +1,8 @@
 module.exports = {
-  PAYMENTSETTINGID: "paypal_complete_payments_application", // Must match your DevCenter App's AppKey
 	PAYPALMULTIPARTYAPPKEY: "paypalMultipartyAppKey", // Required for Kibo to recognize thirdpartyworkflow as PayPal Multiparty implementation
-  PAYPALMULTIPARTYAPPKEYVALUE: "mozuadmin.paypal_complete_payments_application.1.0.0.Release", // Determines which SecureAppData Kibo will pull partner credentials from. TODO pull from install context
+  PAYPALMULTIPARTYAPPKEYVALUE: "mzint.paypal_complete_payments_application.1.0.1.Release", // Determines which SecureAppData Kibo will pull partner credentials from. TODO pull from install context
   PAYPALMULTIPARTYPAYMENTTYPE: "PayPalCompletePayments", //This value will get set as Payment.PaymentType and display in Admin UI as Payment Method
-  PAYPALMULTIPARTYPAYMENTWORKFLOW: "PayPalCompletePayments", //This value will get set as Payment.PaymentWorkflow
+  PAYPALMULTIPARTYPAYMENTWORKFLOW: "PayPalCompletePayments", //This value will get set as Payment.PaymentWorkflow and used for the CheckoutSettings third-party-workflow name
 	ENVIRONMENT: "environment",
 	USERNAME: "username",
 	PASSWORD: "password",

--- a/assets/src/paypal/helper.js
+++ b/assets/src/paypal/helper.js
@@ -51,9 +51,10 @@ var helper = module.exports = {
 		return (queryString.PayerID !== "" &&
 			queryString.token !== "" && queryString.id !== ""  );
 	},
-	getPaymentFQN: function(context) {
+	// Returns the fullyQualifiedName for the PayPal third-party workflow under commerce/settings/checkout/paymentsettings
+	getThirdPartyWorkflowFQN: function(context) {
 		var appInfo = getAppInfo(context);
-		return appInfo.namespace+"~"+paymentConstants.PAYMENTSETTINGID;
+		return appInfo.namespace+"~"+paymentConstants.PAYPALMULTIPARTYPAYMENTWORKFLOW;
 	},
 	getValue: function(paymentSetting,  key) {
 		var value = _.findWhere(paymentSetting.credentials, {"apiName" : key}) || _.findWhere(paymentSetting.Credentials, {"APIName" : key}) ;

--- a/assets/src/paypal/paymenthelper.js
+++ b/assets/src/paypal/paymenthelper.js
@@ -14,7 +14,7 @@ module.exports = {
 	getPaymentConfig: function (context) {
  		var self = this;
 		return helper.createClientFromContext(PaymentSettings, context, true)
-			.getThirdPartyPaymentWorkflowWithValues({ fullyQualifiedName: helper.getPaymentFQN(context) })
+			.getThirdPartyPaymentWorkflowWithValues({ fullyQualifiedName: helper.getThirdPartyWorkflowFQN(context) })
 			.then(function (paypalSettings) {
 				return self.getConfig(paypalSettings);
 			});
@@ -40,7 +40,7 @@ module.exports = {
 	validatePaymentSettings: function (context, callback) {
 		var self = this;
 		var paymentSettings = context.request.body;
-		var paypalSettings = _.findWhere(paymentSettings.externalPaymentWorkflowDefinitions, { fullyQualifiedName: helper.getPaymentFQN(context) });
+		var paypalSettings = _.findWhere(paymentSettings.externalPaymentWorkflowDefinitions, { fullyQualifiedName: helper.getThirdPartyWorkflowFQN(context) });
 		if (!paypalSettings || !paypalSettings.IsEnabled) callback();
 
 		var config = self.getConfig(paypalSettings);


### PR DESCRIPTION
### Summary

Fixes payment processing 404 on third-party workflow lookup:

Corrects [getThirdPartyWorkflowFQN](vscode-file://vscode-app/c:/Users/Travis.Patrick/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (formerly getPaymentFQN) to use [PAYPALMULTIPARTYPAYMENTTYPE](vscode-file://vscode-app/c:/Users/Travis.Patrick/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (PayPalCompletePayments) when building the FQN for the payment workflow lookup, matching the name used at install time.
Addresses issue where calls to /commerce/settings/checkout/paymentsettings/thirdpartyworkflow/mzint~paypal_complete_payments_application 404'd because the installed workflow FQN is mzint~PayPalCompletePayments.
Removes unused PAYMENTSETTINGID constant.
Renames getPaymentFQN to [getThirdPartyWorkflowFQN](vscode-file://vscode-app/c:/Users/Travis.Patrick/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a clarifying comment to better reflect its purpose.

### Jira Ticket

https://kibo.atlassian.net/browse/COM-10354

### Tests

- [ ] Added unit tests
- [ ] Added integration tests

### More Context

Root Cause:
getPaymentFQN built the workflow FQN using PAYMENTSETTINGID (paypal_complete_payments_application), which matches the app's DevCenter AppKey. However, getPaymentDef in paypalInstall registers the workflow using PAYPALMULTIPARTYPAYMENTTYPE (PayPalCompletePayments) as the workflow name. These two values diverged, causing the runtime lookup to target a workflow that does not exist.

Before:

Payment processing and settings validation called getThirdPartyPaymentWorkflowWithValues with FQN mzint~paypal_complete_payments_application, which 404d because no workflow exists under that name.
After:

The FQN is now built from PAYPALMULTIPARTYPAYMENTTYPE, resolving to mzint~PayPalCompletePayments, which matches the workflow registered during install.

### Validation

Verify payment processing completes without a 404 on the third-party workflow lookup.
Verify the validatePaymentSettings action correctly resolves the PayPal workflow when payment settings are saved in the admin UI.

### Risk and Mitigation/Rollback Steps

Risk: Any tenant whose workflow was somehow registered under the old name (paypal_complete_payments_application) would be broken by this change, but this scenario would require a non-standard prior install.

Mitigation: The getPaymentDef install logic has always used PAYPALMULTIPARTYPAYMENTTYPE; this fix aligns the runtime lookup to match it.
Rollback: Revert this commit to restore the previous (broken) FQN lookup behavior.